### PR TITLE
Fixed bug related to functionality of HashMap and identical characters

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -69,17 +69,13 @@
     <option name="showModules" value="false" />
     <option name="sortByType" value="true" />
   </component>
-  <component name="PropertiesComponent">
-    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
-    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
-    <property name="ToolWindowMessages.ShowToolbar" value="false" />
-    <property name="ToolWindowRun.ShowToolbar" value="false" />
-    <property name="project.structure.last.edited" value="Project" />
-    <property name="project.structure.proportion" value="0.15" />
-    <property name="project.structure.side.proportion" value="0.2" />
-    <property name="settings.editor.selected.configurable" value="settings.saveactions" />
-  </component>
-  <component name="RunManager" selected="Application.Anagram">
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true"
+  }
+}]]></component>
+  <component name="RunManager" selected="JUnit.AnagramTests">
     <configuration name="Anagram" type="Application" factoryName="Application">
       <option name="MAIN_CLASS_NAME" value="Anagram" />
       <module name="COS 126" />

--- a/Anagram.java
+++ b/Anagram.java
@@ -2,15 +2,20 @@ import java.util.HashMap;
 
 public class Anagram {
     public static boolean anagram(String oneS, String twoS) {
-        HashMap<Character, Boolean> oneHM = new HashMap<Character, Boolean>();
-        HashMap<Character, Boolean> twoHM = new HashMap<Character, Boolean>();
-        for (char c : oneS.toCharArray()) {
-            oneHM.put(c, true);
+        if (oneS.length() != twoS.length()) {
+            return false;
         }
-        for (char c : twoS.toCharArray()) {
-            twoHM.put(c, true);
+        else {
+            HashMap<Character, Boolean> oneHM = new HashMap<Character, Boolean>();
+            HashMap<Character, Boolean> twoHM = new HashMap<Character, Boolean>();
+            for (char c : oneS.toCharArray()) {
+                oneHM.put(c, true);
+            }
+            for (char c : twoS.toCharArray()) {
+                twoHM.put(c, true);
+            }
+            return oneHM.equals(twoHM);
         }
-        return oneHM.equals(twoHM);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
For strings like "banana" and "ban", the "ana" will overwrite the original 'a' and 'n', resulting in an identical HashMap to "ban" even though ban is not an anagram of banana. To fix the issue I added a conditional that tests if the lengths of the two strings are identical because if they are not, then an anagram cannot be created.