### PR TITLE
Added a length comparison between words

### DIFF
--- a/Anagram.java
+++ b/Anagram.java
@@ -2,6 +2,9 @@ import java.util.HashMap;
 
 public class Anagram {
     public static boolean anagram(String oneS, String twoS) {
+        if (oneS.length() != twoS.length()){
+            return false;
+        }
         HashMap<Character, Boolean> oneHM = new HashMap<Character, Boolean>();
         HashMap<Character, Boolean> twoHM = new HashMap<Character, Boolean>();
         for (char c : oneS.toCharArray()) {


### PR DESCRIPTION
Bug found was that words that consisted of the same letter multiple times did not work with the hash map, leading to shorter words containing the same letters being seen as anagrams of longer words (i.e. "ban" and "banana", since the hashmap just overwrites previously seen keys). To fix this, a few lines were added to check if the words were the same length to begin with, if not the method returns false before utilizing the hash map.